### PR TITLE
The Great Comment Purge of 2019

### DIFF
--- a/UIAL-Main/Engine/ResamplerParameter.cs
+++ b/UIAL-Main/Engine/ResamplerParameter.cs
@@ -5,7 +5,7 @@ using zuoanqh.UIAL.UST;
 namespace zuoanqh.UIAL.Engine
 {
   /// <summary>
-  /// We have referenced parameter meanings from td_fnds's source code here.
+  /// The parameter meanings here are referenced from td_fnds's source code.
   /// 0: input file
   /// 1: output file
   /// 2: note name
@@ -13,7 +13,7 @@ namespace zuoanqh.UIAL.Engine
   /// 4: flags
   /// 5: offset, default VB
   /// 6: length
-  /// (too lazy to continue)
+  /// TODO: describe the rest of the parameters
   /// </summary>
   public class ResamplerParameter
   {
@@ -23,7 +23,7 @@ namespace zuoanqh.UIAL.Engine
     public string OutputFile { get { return Args[1]; } set { Args[1] = value; } }
 
     /// <summary>
-    /// This gives note's note name such as "C3", "F#4".
+    /// This gives the note's "note name" such as "C3", "F#4".
     /// If you want the number in UST file, use "NoteNum", they works the same way.
     /// </summary>
     public string NoteName { get { return Args[2]; } set { Args[2] = value; } }
@@ -73,7 +73,7 @@ namespace zuoanqh.UIAL.Engine
     /// </summary>
     public double Cutoff { get { return Convert.ToDouble(Args[8]); } set { Args[8] = value + ""; } }
     /// <summary>
-    /// for volume, in percentage.
+    /// For volume, in percentage.
     /// </summary>
     public double Intensity { get { return Convert.ToDouble(Args[9]); } set { Args[9] = value + ""; } }
     /// <summary>
@@ -81,22 +81,22 @@ namespace zuoanqh.UIAL.Engine
     /// </summary>
     public double Modulation { get { return Convert.ToDouble(Args[10]); } set { Args[10] = value + ""; } }
     /// <summary>
-    /// There's a ! because there's a !, we don't know why, but everyone's using it that way so we had to do it that way to make it work.
+    /// The purpose of "!" is unclear.
     /// </summary>
     public double Tempo { get { return Convert.ToDouble(Args[11].Substring(1)); } set { Args[11] = "!" + value; } }
     /// <summary>
-    /// To get the processed pitchebnd array, use GetPutchbendArray().
-    /// 
+    /// The encoded raw string. To get the decoded pitchebnd array, use GetPitchbendArray().
     /// </summary>
     public string PitchbendString { get { return Args[12]; } set { Args[12] = value; } }
     /// <summary>
-    /// This decodes the pitchbend string into actual pitchbends in unit of cents, zeroed at given register. They only goes from -2048 to 2048.
+    /// This decodes the pitchbend string into actual pitchbends in unit of cents, zeroed at given register. They only go from -2048 to 2048.
     /// </summary>
     public int[] GetPitchbendArray()
     {return CommonReferences.DecodePitchbends(PitchbendString);    }
     /// <summary>
-    /// Use this if you only change one value in the pitchbend.
-    /// Use "SetPitchbends" for many values.
+    /// Sets the pitchbend value at the given index.
+    /// This modifies the entire string every time.
+    /// Use "SetPitchbends" for efficiently setting many values.
     /// </summary>
     /// <param name="index"></param>
     /// <param name="value"></param>
@@ -107,7 +107,7 @@ namespace zuoanqh.UIAL.Engine
       PitchbendString = CommonReferences.EncodePitchbends(array);
     }
     /// <summary>
-    /// 
+    /// Sets the entire pitchbend for the note.
     /// </summary>
     /// <param name="NewPitchbends"></param>
     public void SetPitchbends(int[] NewPitchbends)
@@ -115,13 +115,12 @@ namespace zuoanqh.UIAL.Engine
       PitchbendString = CommonReferences.EncodePitchbends(NewPitchbends);
     }
     /// <summary>
-    /// Set a region in the original. Start and End both inclusive.
-    /// This is for when you have only the region you want to set.
-    /// if you have the entire array, use SetPitchbends(int[])
+    /// Sets pitchbend between given indicies.
+    /// Use SetPitchbends(int[]) to set the entire array.
     /// </summary>
-    /// <param name="Start">Inclusive.</param>
-    /// <param name="End">Inclusive.</param>
-    /// <param name="Pitchbends">the data for that region.</param>
+    /// <param name="Start">Inclusive</param>
+    /// <param name="End">Inclusive</param>
+    /// <param name="Pitchbends">Pitchbends for the area specified</param>
     public void SetPitchbends(int Start, int End, int[] Pitchbends)
     {
       int[] array = CommonReferences.DecodePitchbends(PitchbendString);
@@ -129,7 +128,8 @@ namespace zuoanqh.UIAL.Engine
       PitchbendString = CommonReferences.EncodePitchbends(array);
     }
     /// <summary>
-    /// This makes it shorter. Don't worry, data will be unchanged.
+    /// Makes the pitchbend string shorter by merging pitchbends of the same pitch.
+    /// TODO: remove side effect of encode/decode
     /// </summary>
     public void RecodePitchbendString()
     {
@@ -150,7 +150,10 @@ namespace zuoanqh.UIAL.Engine
     {
       Args = new string[13];//there's 13 parameters
     }
-
+    /// <summary>
+    /// Create a new instance with given parameters.
+    /// </summary>
+    /// <param name="Args"></param>
     public ResamplerParameter(List<string> Args)
       : this(Args.ToArray())
     { }

--- a/UIAL-Main/UST/Envelope.cs
+++ b/UIAL-Main/UST/Envelope.cs
@@ -5,9 +5,6 @@ using System.Linq;
 
 namespace zuoanqh.UIAL.UST
 {
-  /// <summary>
-  /// This class models a envelope. While the entire idea is bizarre, I'm putting down some code to hopefully make your life easier.
-  /// </summary>
   public class Envelope
   {
     public static readonly double DEFAULT_V4 = 0;
@@ -35,7 +32,7 @@ namespace zuoanqh.UIAL.UST
     /// </summary>
     public double v1 { get { return param[3]; } set { param[3] = value; } }
     /// <summary>
-    /// Time between p1 and p2 in ms. Default while not meaningful, is 5.
+    /// Time between p1 and p2 in ms. Default is 5.
     /// </summary>
     public double p2 { get { return param[1]; } set { param[1] = value; } }
     /// <summary>
@@ -43,7 +40,7 @@ namespace zuoanqh.UIAL.UST
     /// </summary>
     public double v2 { get { return param[4]; } set { param[4] = value; } }
     /// <summary>
-    /// Time before p4 in ms. Default while not meaningful, is 35.
+    /// Time before p4 in ms. Default is 35.
     /// </summary>
     public double p3 { get { return param[2]; } set { param[2] = value; } }
     /// <summary>
@@ -51,7 +48,8 @@ namespace zuoanqh.UIAL.UST
     /// </summary>
     public double v3 { get { return param[5]; } set { param[5] = value; } }
     /// <summary>
-    /// Length of the "blank" at the end in ms. Note this is relative to the length of note this envelope will be applied to.
+    /// Length of the "blank" at the end in ms.
+    /// Note this is relative to the length of the parent note.
     /// </summary>
     public double p4 { get { return param[7]; } set { param[7] = value; } }
     public bool HasP4 { get { return !double.IsNaN(p4); } }
@@ -61,7 +59,7 @@ namespace zuoanqh.UIAL.UST
     public double v4 { get { return param[6]; } set { param[6] = value; } }
 
     /// <summary>
-    /// Time after p2 in ms. Optional (NaN means 0). Default is 10.
+    /// Time after p2 in ms. Default is 10. Optional (NaN means 0).
     /// </summary>
     public double p5 { get { return param[8]; } set { param[8] = value; } }
     public bool HasP5 { get { return !double.IsNaN(p5); } }
@@ -88,13 +86,13 @@ namespace zuoanqh.UIAL.UST
       throw new NotImplementedException();
     }
     /// <summary>
-    /// This is the threshold we consider two v-value equal.
+    /// This is the threshold we consider two v-values to be equal: 0.1%
     /// </summary>
     public static readonly double EPSILON = 0.1;
 
     /// <summary>
     /// This method tries to zero p values. 
-    /// This can fix some envelope problems, so TRY IT!
+    /// This can fix some envelope problems.
     /// </summary>
     public void ZeroPValues()
     {
@@ -108,12 +106,14 @@ namespace zuoanqh.UIAL.UST
     }
 
     /// <summary>
-    /// Please note it seems this does absolutely nothing, so maybe you shouldn't spend time on it.
+    /// Whether the raw data has a "%".
+    /// The purpose of it is unclear -- Perhaps it is obsolete.
     /// </summary>
     public bool HasPercentMark;
 
     /// <summary>
-    /// Check if the envelope is valid given its length in ms.
+    /// Check if the envelope is valid given its note's length in ms.
+    /// An envelope is valid is the length of envelop is smaller the length of the note.
     /// </summary>
     /// <param name="Length"></param>
     /// <returns></returns>
@@ -123,9 +123,9 @@ namespace zuoanqh.UIAL.UST
     }
 
     /// <summary>
-    /// 
+    /// Creates an object from raw UST data.
     /// </summary>
-    /// <param name="Data">As in UST's format.</param>
+    /// <param name="Data"></param>
     public Envelope(string Data)
     {
       param = new double[10];
@@ -159,20 +159,20 @@ namespace zuoanqh.UIAL.UST
         HasPercentMark = false;
     }
     /// <summary>
-    /// Creates the default envelope used in utau: 0,5,35,0,100,100,0,%
+    /// Creates the default envelope: 0,5,35,0,100,100,0,%
     /// </summary>
     public Envelope() : this("0,5,35,0,100,100,0,%")
     { }
 
     /// <summary>
-    /// (Deep) copy constructor. 
+    /// Creates a deep copy of that envelope.
     /// </summary>
     /// <param name="that"></param>
     public Envelope(Envelope that) : this(that.ToString())
     { }
 
     /// <summary>
-    /// Converts it back to original format.
+    /// Converts the object back to its UST format.
     /// </summary>
     /// <returns></returns>
     public override string ToString()

--- a/UIAL-Main/UST/PortamentoSegment.cs
+++ b/UIAL-Main/UST/PortamentoSegment.cs
@@ -1,12 +1,21 @@
 ﻿namespace zuoanqh.UIAL.UST
 {
   /// <summary>
-  /// A data class that hopefully makes your life easier. 
+  /// A data class. 
   /// </summary>
   public class PortamentoSegment
   {
+    /// <summary>
+    /// Length
+    /// </summary>
     public double PBW;
+    /// <summary>
+    /// Pitchbend
+    /// </summary>
     public double PBY;
+    /// <summary>
+    /// Curve Type Identifier
+    /// </summary>
     public string PBM;
 
     public PortamentoSegment(double PBW, double PBY, string PBM)

--- a/UIAL-Main/UST/USTNote.cs
+++ b/UIAL-Main/UST/USTNote.cs
@@ -7,12 +7,14 @@ using System;
 namespace zuoanqh.UIAL.UST
 {
   /// <summary>
-  /// This class models a note inside a ust. When it comes to ust, we would like to say (again) FUCK SHIFT-JIS. 
-  /// Please note attribute "Envelope", "Portamento" and "Vibrato" was handled by separate, mutable classes.
-  /// You can access their text from here or parsed data from those objects, they do not preserve input, but are more reliable.
-  /// "FlagText" preserves input, while "Flags" works perfectly with all known flags, all unknown flags with parameters,
-  /// but will have problem with unknown no-parameter flags when they are next to another unknown flag because the grammar itself is fucked up. 
+  /// This class models a note inside a ust. 
+  /// Attributes "Envelope", "Portamento" and "Vibrato" are handled by separate, mutable classes due to their complexity.
+  /// You can access their original text from here, or parsed data from those objects. They are more reliable(TODO: Find out what 3-years-ago me meant by this).
+  /// Converting parsed object back to string won't preserve input.
+  /// For flags, "FlagText" preserves input, while "Flags" provides convenience. "Flags"
   /// You can handle it yourselves, or add it to the settings.
+  /// TODO: This comment is too long.
+  /// TODO: Refactor original texts into respective classes
   /// </summary>
   public class USTNote
   {
@@ -39,7 +41,7 @@ namespace zuoanqh.UIAL.UST
     public const string KEY_VBR = "VBR";
 
     /// <summary>
-    /// This contains all attribute we know could exist in a note.
+    /// This contains the name of all known attributes a note can have.
     /// </summary>
     public static readonly IReadOnlyList<string> KNOWN_ATTRIBUTE_NAMES;
 
@@ -52,7 +54,7 @@ namespace zuoanqh.UIAL.UST
     }
 
     /// <summary>
-    /// Make a rest note.
+    /// Create a rest ("R") note.
     /// </summary>
     /// <param name="length"></param>
     /// <returns></returns>
@@ -60,9 +62,9 @@ namespace zuoanqh.UIAL.UST
     { return new USTNote(length, "R", "C3"); }
 
     /// <summary>
-    /// Make a note without specifying all the stupid parameters. This will make 240, "あ", "C3". 
-    /// We does not have an empty constructor because it is required a note have that three fields.
-    /// to preserve encapsulation we can't make an "empty" object.
+    /// Create a note with default parameters.
+    /// This will make a note of length 240, lyric "あ", note name "C3". 
+    /// A note need to have at least these three parameters.
     /// </summary>
     /// <returns></returns>
     public static USTNote MakeDefault()
@@ -70,41 +72,39 @@ namespace zuoanqh.UIAL.UST
       return new USTNote(240, "あ", "C3");
     }
 
-    //This was for debugging. we debugged. it works fine.
+    //for debugging
     //public List<string> TextRaw;
 
     /// <summary>
-    /// Or you can access your attributes this way i guess.... not judging...
+    /// Access the raw text of each attribute with their key.
     /// Please note you cannot access envelope, portamento or vibrato of the note here. 
-    /// If for compatibility reasons you prefer their text format, we have attributes for you.
-    /// 
+    /// Their raw text is available from their respective attributes.
     /// </summary>
     public IReadOnlyDictionary<string, string> Attributes { get { return attributes; } }
-
     private DictionaryDataObject attributes;
 
     /// <summary>
-    /// Must-have attribute. Ticks. Must >= 15.
+    /// Mandatory. Ticks. Must >= 15.
     /// </summary>
     public int Length
     {
       get { return attributes.GetAsInt(KEY_LENGTH); }
-      set { attributes.Set(KEY_PREUTTERANCE, value); }
+      set { attributes.Set(KEY_PREUTTERANCE, value); } // FIXME
     }
 
     /// <summary>
-    /// Must-have (Duh). "R" triple-equals rest. Lyric combined with postfix should be in the oto-aliases.
+    /// Mandatory. "R" means rest. Lyric combined with postfix should be in the oto-aliases.
     /// </summary>
     public string Lyric
     {
       get { return attributes[KEY_LYRIC]; }
-      set { attributes.Set(KEY_PREUTTERANCE, value); }
+      set { attributes.Set(KEY_PREUTTERANCE, value); } // FIXME
     }
     public bool IsRest()
     { return Lyric.Equals("R"); }
 
     /// <summary>
-    /// This ranges from 24(C1) to 107(B7). It's probably the god-damned mathematical convenience working up again.
+    /// Mandatory. Ranges from 24(C1) to 107(B7).
     /// </summary>
     public int NoteNum
     {
@@ -113,7 +113,8 @@ namespace zuoanqh.UIAL.UST
     }
 
     /// <summary>
-    /// Default: empty (VB value). In milliseconds. This will be rounded off to 3 digits after decimal point by UTAU. 
+    /// Default: empty (VB value). In milliseconds. 
+    /// This is rounded off to 3 digits after the decimal point by UTAU.
     /// </summary>
     public double PreUtterance
     {
@@ -122,7 +123,7 @@ namespace zuoanqh.UIAL.UST
     }
 
     /// <summary>
-    /// For a modern user experience, use "Flags" attribute. This is for when things broke.
+    /// For parsed flags, use "Flags" attribute.
     /// </summary>
     public string FlagText
     {
@@ -131,8 +132,7 @@ namespace zuoanqh.UIAL.UST
     }
 
     /// <summary>
-    /// Note Flags class is immutable. to apply (add or update) a flag value, use Flags = Flags.WithFlagValue()
-    /// Yes, this is incredibly inefficient and goes text to flags to text to flags to text to flags for one edit. but it works. what more do you ask?
+    /// Immutable.
     /// </summary>
     public Flags Flags
     {
@@ -141,7 +141,7 @@ namespace zuoanqh.UIAL.UST
     }
 
     /// <summary>
-    /// Percentage. This will be rounded to an integer by UTAU.
+    /// Percentage. This is rounded to an integer by UTAU.
     /// </summary>
     public int Intensity
     {
@@ -149,7 +149,7 @@ namespace zuoanqh.UIAL.UST
       set { attributes.Set(KEY_INTENSITY, value); }
     }
     /// <summary>
-    /// Percentage. This will be rounded to an integer by UTAU.
+    /// Percentage. This is rounded to an integer by UTAU.
     /// </summary>
     public int Modulation
     {
@@ -158,7 +158,7 @@ namespace zuoanqh.UIAL.UST
     }
 
     /// <summary>
-    /// In milliseconds. This will be rounded off to 3 digits after decimal point by UTAU. 
+    /// In milliseconds. This is rounded off to 3 digits after decimal point by UTAU. 
     /// </summary>
     public double VoiceOverlap
     {
@@ -167,7 +167,7 @@ namespace zuoanqh.UIAL.UST
     }
 
     /// <summary>
-    /// This should be between 0 and 200. 
+    /// Must be between 0 and 200. 
     /// </summary>
     public double Velocity
     {
@@ -175,7 +175,8 @@ namespace zuoanqh.UIAL.UST
       set { attributes.Set(KEY_VELOCITY, value); }
     }
     /// <summary>
-    /// This allow you to manipulate the velocity with desired factor value instead. This should be between 0.5 (half as long, fastest) to 2 (twice as long, slowest)
+    /// Manipulate the velocity with the effective factor instead. 
+    /// This should be between 0.5 (half as long, fastest) to 2 (twice as long, slowest)
     /// </summary>
     public double VelocityFactor
     {
@@ -184,6 +185,7 @@ namespace zuoanqh.UIAL.UST
     }
 
     /// <summary>
+    /// TODO: Compatible with what?
     /// This exists for compatibility, it converts the envelope back and forth to strings when you use it.
     /// </summary>
     public string EnvelopeText
@@ -193,33 +195,33 @@ namespace zuoanqh.UIAL.UST
     }
 
     /// <summary>
-    /// The envelope of the note. default is "0,5,35,0,100,100,0,%", or new Envelope()
+    /// Default is "0,5,35,0,100,100,0,%", and can be created by "new Envelope()"
     /// </summary>
     public Envelope Envelope;
 
     /// <summary>
-    /// To access the strings, 
+    /// Can be null. Null means the attribute does not exist.
     /// </summary>
     public Portamento Portamento;
 
     /// <summary>
-    /// This can be null, sorry. null means the attribute does not exist.
+    /// Can be null. Null means the attribute does not exist.
     /// </summary>
     public Vibrato Vibrato;
 
-    //you know what, Maybe I'll just not do these, you can still use attributes.Get.
+    // These exist in older usts. Parsing is to be implemented.
     ///// <summary>
-    ///// This field is deprecated, we did not bother to find out what it means.
+    ///// This field is deprecated. Pitchbend type perhaps?
     ///// </summary>
     //public int PBType;
     //
     ///// <summary>
-    ///// This is for mode 1. (that means you may ignore it) (that means please do ignore it)
+    ///// This is for mode 1 pitchbend.
     ///// </summary>
     //public List<int> Pitches;
 
     /// <summary>
-    /// Create the note from raw text in format of ust files.
+    /// Create a note from text in the format of ust files.
     /// </summary>
     /// <param name="list"></param>
     public USTNote(List<string> list)
@@ -245,7 +247,7 @@ namespace zuoanqh.UIAL.UST
       attributes.Remove(KEY_VBR);
     }
     /// <summary>
-    /// make a note with minimum data and default envelope.
+    /// Create a note with minimum data and a default envelope.
     /// </summary>
     /// <param name="Length"></param>
     /// <param name="Lyric"></param>
@@ -260,7 +262,7 @@ namespace zuoanqh.UIAL.UST
     }
 
     /// <summary>
-    /// This will convert the NoteName to NoteNum.
+    /// Create a note with minimum data and a default envelope, with note name (e.g. "C1") specified instead of "NoteNum" (e.g. 24).
     /// </summary>
     /// <param name="Length"></param>
     /// <param name="Lyric"></param>
@@ -276,7 +278,7 @@ namespace zuoanqh.UIAL.UST
     public USTNote(USTNote another)
       : this(another.ToStringList())
     {
-      //giving up....
+      //TODO: implement this more efficiently
       //this.attributes = new DictionaryDataObject(another.attributes);
       //this.Envelope = new Envelope(another.Envelope);
       //if (another.Portamento != null) this.Portamento = new Portamento(another.Portamento);
@@ -284,7 +286,7 @@ namespace zuoanqh.UIAL.UST
     }
 
     /// <summary>
-    /// Converts it back to its ust format. 
+    /// Converts the note back to its ust format. 
     /// </summary>
     /// <returns></returns>
     public List<string> ToStringList()
@@ -298,7 +300,7 @@ namespace zuoanqh.UIAL.UST
     }
 
     /// <summary>
-    /// Converts it back to its ust format. 
+    /// Converts the note back to its ust format.
     /// </summary>
     /// <returns></returns>
     public override string ToString()

--- a/UIAL-Main/UST/Vibrato.cs
+++ b/UIAL-Main/UST/Vibrato.cs
@@ -5,14 +5,13 @@ using System.Linq;
 namespace zuoanqh.UIAL.UST
 {
   /// <summary>
-  /// This models a vibrato. 
-  /// Use ToString() to access the string format if you really have to.
+  /// This models a the vibrato of a note. 
   /// </summary>
   public class Vibrato
   {
     /// <summary>
     /// The 7 parameters, in order, are: length (% of declared length of note), cycle(ms), depth(cent), in(%), out(%), phase(%), pitch(%).
-    /// We don't know what the 8th parameter does.
+    /// It's unclear what the 8th parameter does. TODO: find out
     /// pitch is the "y offset", percentage on depth, while phase is the x offset.
     /// length works even if it's >100%.
     /// </summary>
@@ -31,7 +30,7 @@ namespace zuoanqh.UIAL.UST
     /// </summary>
     public double Depth { get { return Parameters[2]; } set { Parameters[2] = value; } }
     /// <summary>
-    /// The linear fade-in part in percents. Default is 20.
+    /// The linear fade-in part. In percentage. Default is 20.
     /// </summary>
     public double In
     {
@@ -39,12 +38,12 @@ namespace zuoanqh.UIAL.UST
       set
       {
         if ((value + Out) > 100)
-          throw new ArgumentException(String.Format("This is highly Illogical. In = {0}%, In + Out = {1}% >100%", value, value + Out));
+          throw new ArgumentException(String.Format("Invalid Parameter. In = {0}%, In + Out = {1}% >100%", value, value + Out));
         Parameters[3] = value;
       }
     }
     /// <summary>
-    /// The linear face-out part in percents. Default is 20.
+    /// The linear face-out part. In percentage. Default is 20.
     /// </summary>
     public double Out
     {
@@ -52,16 +51,17 @@ namespace zuoanqh.UIAL.UST
       set
       {
         if ((value + In) > 100)
-          throw new ArgumentException(String.Format("This is highly Illogical. Out = {0}%, In + Out = {1}% >100%", value, value + In));
+          throw new ArgumentException(String.Format("Invalid Parameter. Out = {0}%, In + Out = {1}% >100%", value, value + In));
         Parameters[4] = value;
       }
     }
     /// <summary>
-    /// The time-axis shift of sine wave, in percents. Default is 20.
+    /// The time-axis shift of the sine wave, in percentage. Default is 20.
     /// </summary>
     public double Phase { get { return Parameters[5]; } set { Parameters[5] = value; } }
     /// <summary>
-    /// The pitch shift of sine wave (why would you want to do this?), in percents (also why percents?), Default is 20.
+    /// The pitch shift of the sine wave (uncommon in practice), in percentage, Default is 20.
+    /// TODO: percentage of WHAT?
     /// </summary>
     public double Pitch { get { return Parameters[6]; } set { Parameters[6] = value; } }
 
@@ -75,7 +75,7 @@ namespace zuoanqh.UIAL.UST
     }
 
     /// <summary>
-    /// Returns the last parameter which is useless AFAIK.
+    /// Returns the last parameter. Its purpose is unclear.
     /// </summary>
     public double EighthParameter { get { return Parameters[7]; } set { Parameters[7] = value; } }
 
@@ -114,7 +114,7 @@ namespace zuoanqh.UIAL.UST
 
     /// <summary>
     /// Returns the magnitude of pitchbend in cents at given time. 
-    /// Due to terrible interface given to us, length is required.
+    /// Since everything is in percentage, the length is required.
     /// Note this will return 0 if time is outside range, will not throw exceptions.
     /// </summary>
     /// <param name="AtTime">time since 0%</param>
@@ -122,6 +122,7 @@ namespace zuoanqh.UIAL.UST
     /// <returns></returns>
     public double Sample(double AtTime, double Length)
     {
+      // TODO: refactor this to work without length and create a wrapper overload
       double len = Length * this.Length;//vibrato length in ms
       double blank = Length - len;
       if (AtTime < blank || AtTime > Length) return 0;//just some house keeping.

--- a/UIAL-Main/VB/Frq.cs
+++ b/UIAL-Main/VB/Frq.cs
@@ -4,6 +4,7 @@ namespace zuoanqh.UIAL.VB
 {
   /// <summary>
   /// This class allows editing of a .frq file.
+  /// TODO: write file
   /// </summary>
   public class Frq
   {
@@ -11,8 +12,8 @@ namespace zuoanqh.UIAL.VB
     /// 40 bytes of data, which we believe is made with (in order) 
     /// 8 bytes of "FREQ0003", 
     /// 12 bytes of data, 
-    /// 16 bytes of " speedwagon     ", (I tried to google but found nothing... anyone knows why?)
-    /// 4 bytes of data of how many entries are there.
+    /// 16 bytes of " speedwagon     ", (No idea what it does)
+    /// 4 bytes of data on how many entries are there.
     /// </summary>
     public byte[] Header;
 

--- a/UIAL-Main/VB/Oto.cs
+++ b/UIAL-Main/VB/Oto.cs
@@ -9,7 +9,7 @@ namespace zuoanqh.UIAL.VB
   public class Oto
   {
     /// <summary>
-    /// This is meant to be true at all time, except for debugging.
+    /// for debugging
     /// </summary>
     public static bool CHECK_ENCODING = true;
 
@@ -32,7 +32,7 @@ namespace zuoanqh.UIAL.VB
       Aliases = new Dictionary<string, OtoAlias>();
       Extras = new Dictionary<string, List<OtoAlias>>();
 
-      AliasesOrdered = Data.Select((s) => new OtoAlias(s)).ToArray();//This will ensure the order from the file is preserved.
+      AliasesOrdered = Data.Select((s) => new OtoAlias(s)).ToArray();//This ensures the order from the file is preserved.
 
       UpdateAliasesAndExtras();
     }

--- a/UIAL-Main/VB/OtoAlias.cs
+++ b/UIAL-Main/VB/OtoAlias.cs
@@ -9,7 +9,7 @@ namespace zuoanqh.UIAL.VB
     public string FName, Alias;
 
     /// <summary>
-    /// This would've been private. Please do not bully it.
+    /// This is public for convenience, for now.
     /// </summary>
     public double[] numbers;
 

--- a/UIAL-Main/VB/PrefixMap.cs
+++ b/UIAL-Main/VB/PrefixMap.cs
@@ -7,12 +7,14 @@ using System;
 namespace zuoanqh.UIAL.VB
 {
   /// <summary>
-  /// Model for prefix.map file. Please note despite it saying prefix, it is applied as a postfix.
+  /// Model for prefix.map file.
+  /// Note despite it is called prefix, it is applied as a suffix.
+  /// TODO: what is note index rank?
   /// </summary>
   public class PrefixMap
   {
     /// <summary>
-    /// Note Name to Prefix.
+    /// Note name to prefix.
     /// </summary>
     public Dictionary<string, string> Map;
 
@@ -20,9 +22,9 @@ namespace zuoanqh.UIAL.VB
     { }
 
     /// <summary>
-    /// Create an object with given data. will check if all note names are present.
+    /// Create an object with given data. Checks if all note names are present.
     /// </summary>
-    /// <param name="Data">Lines in the file. Yes, you need to turn a file into lines. Because stupid windows store framework whatever don't allow main thread to read file</param>
+    /// <param name="Data">Lines in the file. For windows store compatibility.</param>
     public PrefixMap(string[] Data)
     {
       Map = new Dictionary<string, string>();
@@ -32,10 +34,10 @@ namespace zuoanqh.UIAL.VB
 
 
     /// <summary>
-    /// Set everything in given range to given mapping, both inclusive.
+    /// Set everything in the given range to given mapping, both inclusive.
     /// </summary>
-    /// <param name="From">Note Name</param>
-    /// <param name="To">Note Name</param>
+    /// <param name="From">Note name</param>
+    /// <param name="To">Note name</param>
     /// <param name="Mapping"></param>
     public void SetRange(string From, string To, string Mapping)
     {
@@ -44,12 +46,11 @@ namespace zuoanqh.UIAL.VB
     /// <summary>
     /// Set everything in given range to given mapping, both inclusive.
     /// </summary>
-    /// <param name="From">Note Name</param>
-    /// <param name="To">Note Name</param>
+    /// <param name="From">Note index</param>
+    /// <param name="To">Note index</param>
     /// <param name="Mapping"></param>
     private void SetRange(int From, int To, string Mapping)
     {
-      //ensure order because sometimes you want to do C3 to C4, sometimes C4 to C3. ok?
       if (From > To) { From ^= To; To ^= From; From ^= To; }
 
       for (int i = From; i <= To; i++) Map[CommonReferences.NOTENAMES[i]] = Mapping;


### PR DESCRIPTION
One strength of UIAL is that it's well-documented. 

However, the comments are littered with personal quips about the ust format. They are long and uninformative, hindering the reader's ability to quickly understand how to work with the library.

**With this purge, we remove these comments in the hope of improving readability.**

Other minor grammatical adjustments are made. All comments have been re-read and re-written if unclear as well.  TODOs are added.

There are still more fixes need to be done on the comments, but they are outside the scope of this pull request.